### PR TITLE
Faster and more correct tile fraction calculation

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,13 +38,10 @@ function tile2lat(y, z) {
 }
 
 function pointToTile(lon, lat, z) {
-    var latr = lat*d2r,
-        z2 = Math.pow(2, z);
-    return [
-        (Math.floor((lon+180)/360*z2)),
-        (Math.floor((1-Math.log(Math.tan(latr) + 1/Math.cos(latr))/Math.PI)/2 *z2)),
-        z
-    ];
+    var tile = pointToTileFraction(lon, lat, z);
+    tile[0] = Math.floor(tile[0]);
+    tile[1] = Math.floor(tile[1]);
+    return tile;
 }
 
 function getChildren (tile) {
@@ -167,19 +164,14 @@ function getBboxZoom(bbox) {
     return MAX_ZOOM;
 }
 
-function pointToTileFraction (lon, lat, z) {
-    var tile = pointToTile(lon, lat, z);
-    var bbox = tileToBBOX(tile);
-
-    var xTileOffset = bbox[2] - bbox[0];
-    var xPointOffset = lon - bbox[0];
-    var xPercentOffset = xPointOffset / xTileOffset;
-
-    var yTileOffset = bbox[1] - bbox[3];
-    var yPointOffset = lat - bbox[3];
-    var yPercentOffset = yPointOffset / yTileOffset;
-
-    return [tile[0]+xPercentOffset, tile[1]+yPercentOffset, z];
+function pointToTileFraction(lon, lat, z) {
+    var latr = lat*d2r,
+        z2 = Math.pow(2, z);
+    return [
+        (lon+180)/360*z2,
+        (1-Math.log(Math.tan(latr) + 1/Math.cos(latr))/Math.PI)/2 *z2,
+        z
+    ];
 }
 
 module.exports = {

--- a/test.js
+++ b/test.js
@@ -176,7 +176,7 @@ test('pointToTileFraction', function(t) {
     var tile = tilebelt.pointToTileFraction(-95.93965530395508,41.26000108568697,9);
     t.ok(tile, 'convert point to tile fraction');
     t.equal(tile[0], 119.552490234375);
-    t.equal(tile[1], 191.4701834281966);
+    t.equal(tile[1], 191.47119140625);
     t.equal(tile[2], 9);
     t.end();
 });


### PR DESCRIPTION
Makes the tile fraction calculation more correct (IMO) since it's now a direct projection rather than a combination of projection and linear interpolation inside a tile. It's also much much faster because it doesn't do unnecessary work.

Interestingly, this also addresses the discrepancy between Node 0.10 and 0.12 described here https://github.com/mapbox/tile-cover/pull/63#issuecomment-86706900 — after this fix, tile-cover will behave in 0.10 exactly like in 0.12. 

cc @morganherlocker 