### PR TITLE
stop returning invalid x tile values in pointToTile

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,6 +156,8 @@ function pointToTileFraction(lon, lat, z) {
         z2 = Math.pow(2, z),
         x = z2 * (lon / 360 + 0.5),
         y = z2 * (0.5 - 0.25 * Math.log((1 + sin) / (1 - sin)) / Math.PI);
+    if (x >= z2) x = z2 - 1;
+    if (y >= z2) x = z2 - 1;
     return [x, y, z];
 }
 

--- a/test.js
+++ b/test.js
@@ -192,3 +192,9 @@ test('pointToTileFraction', function (t) {
     t.equal(tile[2], 9);
     t.end();
 });
+
+test('point to tile -- max longitude', function (t) {
+    var tile = tilebelt.pointToTile(180, 0, 0);
+    t.deepEqual(tile, [0, 0, 0]);
+    t.end();
+});


### PR DESCRIPTION
Currently `pointToTile` on coordinates with +180 longitude will result in invalid X tile coordinates. IE:

``` js
tilebelt.pointToTile(180, 0, 0);
```

yields `[1, 0, 0]` instead of `[0, 0, 0]`

cc @mourner 
