### PR TITLE
simplify getParent

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,20 +104,7 @@ function getChildren(tile) {
  * //=tile
  */
 function getParent(tile) {
-    // top left
-    if (tile[0] % 2 === 0 && tile[1] % 2 === 0) {
-        return [tile[0] / 2, tile[1] / 2, tile[2] - 1];
-    }
-    // bottom left
-    if ((tile[0] % 2 === 0) && (!tile[1] % 2 === 0)) {
-        return [tile[0] / 2, (tile[1] - 1) / 2, tile[2] - 1];
-    }
-    // top right
-    if ((!tile[0] % 2 === 0) && (tile[1] % 2 === 0)) {
-        return [(tile[0] - 1) / 2, (tile[1]) / 2, tile[2] - 1];
-    }
-    // bottom right
-    return [(tile[0] - 1) / 2, (tile[1] - 1) / 2, tile[2] - 1];
+    return [tile[0] >> 1, tile[1] >> 1, tile[2] - 1];
 }
 
 function getSiblings(tile) {


### PR DESCRIPTION
a bit faster and - more importantly - a lot simpler

_before_

    getParent#tile1 x 8,337,504 ops/sec ±0.38% (101 runs sampled)
    getParent#tile2 x 26,560,943 ops/sec ±0.23% (100 runs sampled)

_after_

    getParent#tile1 x 29,505,022 ops/sec ±0.56% (100 runs sampled)
    getParent#tile2 x 29,644,335 ops/sec ±0.29% (103 runs sampled)
