### PR TITLE
Fix Tile X wrapping issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,7 +290,7 @@ function pointToTileFraction(lon, lat, z) {
 }
 
 /**
- * Wrap Tile -- Handles tiles which crosses the 180th meridian or 90th parallel
+ * Wrap Tile -- Handles tiles which crosses the 180th meridian
  *
  * @param {[number, number, number]} tile Tile
  * @param {number} zoom Zoom Level

--- a/index.js
+++ b/index.js
@@ -286,40 +286,11 @@ function pointToTileFraction(lon, lat, z) {
         z2 = Math.pow(2, z),
         x = z2 * (lon / 360 + 0.5),
         y = z2 * (0.5 - 0.25 * Math.log((1 + sin) / (1 - sin)) / Math.PI);
-    return wrapTile([x, y, z]);
-}
 
-/**
- * Wrap Tile -- Handles tiles which crosses the 180th meridian
- *
- * @param {[number, number, number]} tile Tile
- * @param {number} zoom Zoom Level
- * @returns {[number, number, number]} Wrapped Tile
- * @example
- * wrapTile([0, 3, 2])
- * //= [0, 3, 2] -- Valid Tile X
- * wrapTile([4, 2, 2])
- * //= [0, 2, 2] -- Tile X 4 does not exist, wrap around to TileX=0
- */
-function wrapTile(tile) {
-    var tx = tile[0]
-    var ty = tile[1]
-    var zoom = tile[2]
-
-    // Maximum tile allowed
-    // zoom 0 => 1
-    // zoom 1 => 2
-    // zoom 2 => 4
-    // zoom 3 => 8
-    var maxTile = Math.pow(2, zoom)
-
-    // Handle Tile X
-    tx = tx % maxTile
-    if (tx < 0) tx = tx + maxTile
-
-    // Handle Tile Y
-    // Do not wrap Tile Y
-    return [tx, ty, zoom]
+    // Wrap Tile X
+    x = x % z2
+    if (x < 0) x = x + z2
+    return [x, y, z];
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -286,7 +286,40 @@ function pointToTileFraction(lon, lat, z) {
         z2 = Math.pow(2, z),
         x = z2 * (lon / 360 + 0.5),
         y = z2 * (0.5 - 0.25 * Math.log((1 + sin) / (1 - sin)) / Math.PI);
-    return [x, y, z];
+    return wrapTile([x, y, z]);
+}
+
+/**
+ * Wrap Tile -- Handles tiles which crosses the 180th meridian or 90th parallel
+ *
+ * @param {[number, number, number]} tile Tile
+ * @param {number} zoom Zoom Level
+ * @returns {[number, number, number]} Wrapped Tile
+ * @example
+ * wrapTile([0, 3, 2])
+ * //= [0, 3, 2] -- Valid Tile X
+ * wrapTile([4, 2, 2])
+ * //= [0, 2, 2] -- Tile X 4 does not exist, wrap around to TileX=0
+ */
+function wrapTile(tile) {
+    var tx = tile[0]
+    var ty = tile[1]
+    var zoom = tile[2]
+
+    // Maximum tile allowed
+    // zoom 0 => 1
+    // zoom 1 => 2
+    // zoom 2 => 4
+    // zoom 3 => 8
+    var maxTile = Math.pow(2, zoom)
+
+    // Handle Tile X
+    tx = tx % maxTile
+    if (tx < 0) tx = tx + maxTile
+
+    // Handle Tile Y
+    // Do not wrap Tile Y
+    return [tx, ty, zoom]
 }
 
 module.exports = {

--- a/test.js
+++ b/test.js
@@ -195,6 +195,7 @@ test('pointToTileFraction', function (t) {
 
 test('pointToTile -- cross meridian', function (t) {
     // X axis
+    t.deepEqual(tilebelt.pointToTile(-180, 0, 0), [0, 0, 0], '[-180, 0] zoom 0')
     t.deepEqual(tilebelt.pointToTile(-180, 85, 2), [0, 0, 2], '[-180, 85] zoom 2')
     t.deepEqual(tilebelt.pointToTile(180, 85, 2), [0, 0, 2], '[+180, 85] zoom 2')
     t.deepEqual(tilebelt.pointToTile(-185, 85, 2), [3, 0, 2], '[-185, 85] zoom 2')

--- a/test.js
+++ b/test.js
@@ -192,3 +192,17 @@ test('pointToTileFraction', function (t) {
     t.equal(tile[2], 9);
     t.end();
 });
+
+test('pointToTile -- cross meridian', function (t) {
+    // X axis
+    t.deepEqual(tilebelt.pointToTile(-180, 85, 2), [0, 0, 2], '[-180, 85] zoom 2')
+    t.deepEqual(tilebelt.pointToTile(180, 85, 2), [0, 0, 2], '[+180, 85] zoom 2')
+    t.deepEqual(tilebelt.pointToTile(-185, 85, 2), [3, 0, 2], '[-185, 85] zoom 2')
+    t.deepEqual(tilebelt.pointToTile(185, 85, 2), [0, 0, 2], '[+185, 85] zoom 2')
+
+    // Y axis
+    // Does not wrap Tile Y
+    t.deepEqual(tilebelt.pointToTile(-175, -95, 2), [0, 3, 2], '[-175, -95] zoom 2')
+    t.deepEqual(tilebelt.pointToTile(-175, 95, 2), [0, 0, 2], '[-175, +95] zoom 2')
+    t.end()
+})

--- a/test.js
+++ b/test.js
@@ -195,15 +195,22 @@ test('pointToTileFraction', function (t) {
 
 test('pointToTile -- cross meridian', function (t) {
     // X axis
-    t.deepEqual(tilebelt.pointToTile(-180, 0, 0), [0, 0, 0], '[-180, 0] zoom 0')
-    t.deepEqual(tilebelt.pointToTile(-180, 85, 2), [0, 0, 2], '[-180, 85] zoom 2')
-    t.deepEqual(tilebelt.pointToTile(180, 85, 2), [0, 0, 2], '[+180, 85] zoom 2')
-    t.deepEqual(tilebelt.pointToTile(-185, 85, 2), [3, 0, 2], '[-185, 85] zoom 2')
-    t.deepEqual(tilebelt.pointToTile(185, 85, 2), [0, 0, 2], '[+185, 85] zoom 2')
+    // https://github.com/mapbox/tile-cover/issues/75
+    // https://github.com/mapbox/tilebelt/pull/32
+    t.deepEqual(tilebelt.pointToTile(-180, 0, 0), [0, 0, 0], '[-180, 0] zoom 0');
+    t.deepEqual(tilebelt.pointToTile(-180, 85, 2), [0, 0, 2], '[-180, 85] zoom 2');
+    t.deepEqual(tilebelt.pointToTile(180, 85, 2), [0, 0, 2], '[+180, 85] zoom 2');
+    t.deepEqual(tilebelt.pointToTile(-185, 85, 2), [3, 0, 2], '[-185, 85] zoom 2');
+    t.deepEqual(tilebelt.pointToTile(185, 85, 2), [0, 0, 2], '[+185, 85] zoom 2');
 
     // Y axis
     // Does not wrap Tile Y
-    t.deepEqual(tilebelt.pointToTile(-175, -95, 2), [0, 3, 2], '[-175, -95] zoom 2')
-    t.deepEqual(tilebelt.pointToTile(-175, 95, 2), [0, 0, 2], '[-175, +95] zoom 2')
-    t.end()
-})
+    t.deepEqual(tilebelt.pointToTile(-175, -95, 2), [0, 3, 2], '[-175, -95] zoom 2');
+    t.deepEqual(tilebelt.pointToTile(-175, 95, 2), [0, 0, 2], '[-175, +95] zoom 2');
+    t.deepEqual(tilebelt.pointToTile(-175, 95, 2), [0, 0, 2], '[-175, +95] zoom 2');
+
+    // BBox
+    // https://github.com/mapbox/tilebelt/issues/12
+    t.deepEqual(tilebelt.bboxToTile([-0.000001, -85, 1000000, 85]), [0, 0, 0]);
+    t.end();
+});


### PR DESCRIPTION
## Wraps Tile X

Wraps Tile X from `pointToTile` & `pointToTileFraction` based on the maximum Tile X allowed `Math.pow(2, zoom)`.

Fixes issue in `tile-cover` https://github.com/mapbox/tile-cover/issues/75

Also fixes https://github.com/mapbox/tilebelt/issues/12

Ref: https://github.com/mapbox/tilebelt/pull/27
CC: @tcql @mourner @lily-chai 