### PR TITLE
Fixes winding of GeoJSON to follow right-hand rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,11 +36,11 @@ function tileToGeoJSON(tile) {
     var poly = {
         type: 'Polygon',
         coordinates: [[
-            [bbox[0], bbox[1]],
             [bbox[0], bbox[3]],
-            [bbox[2], bbox[3]],
+            [bbox[0], bbox[1]],
             [bbox[2], bbox[1]],
-            [bbox[0], bbox[1]]
+            [bbox[2], bbox[3]],
+            [bbox[0], bbox[3]]
         ]]
     };
     return poly;

--- a/test.js
+++ b/test.js
@@ -9,6 +9,13 @@ test('tile to geojson', function (t) {
     var geojson = tilebelt.tileToGeoJSON(tile1);
     t.ok(geojson, 'get geojson representation of tile');
     t.equal(geojson.type, 'Polygon');
+    t.deepEqual(geojson.coordinates, [[
+        [-178.2421875, 84.73838712095339],
+        [-178.2421875, 84.7060489350415],
+        [-177.890625, 84.7060489350415],
+        [-177.890625, 84.73838712095339],
+        [-178.2421875, 84.73838712095339]
+    ]], 'Coordinates');
     t.end();
 });
 


### PR DESCRIPTION
Changes the winding of a tile's GeoJSON boundary to follow the right-hand rule.

closes #35 