### PR TITLE
"Module not found: Default condition should be last one"  occur when import @mapbox/tilebelt

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "exports": {
     ".": {
       "require": {
-        "default": "./dist/cjs/index.js",
-        "types": "./dist/cjs/index.d.ts"
+        "types": "./dist/cjs/index.d.ts",
+        "default": "./dist/cjs/index.js"
       },
       "import": {
-        "default": "./dist/esm/index.js",
-        "types": "./dist/esm/index.d.ts"
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
       }
     }
   },


### PR DESCRIPTION
"Module not found: Default condition should be last one"  occur when import @mapbox/tilebelt.

"default" and "types" of "exports" change order and this error doesn't occur.